### PR TITLE
ANSI on Windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = CRLF
+
+; 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+[c]
+indent_style = space
+indent_size = 4

--- a/c
+++ b/c
@@ -7,6 +7,7 @@ import os
 import json
 import itertools
 import shutil
+import platform
 
 commands = ['c', 'v', 'del', 'p', 'R', 'h', ]
 
@@ -20,13 +21,14 @@ class C:
     FAIL = '\033[91m'
     ENDC = '\033[0m'
 
-    def disable(self):
-        self.HEADER = ''
-        self.OKBLUE = ''
-        self.OKGREEN = ''
-        self.WARNING = ''
-        self.FAIL = ''
-        self.ENDC = ''
+    @classmethod
+    def disable(cls):
+        cls.HEADER = ''
+        cls.OKBLUE = ''
+        cls.OKGREEN = ''
+        cls.WARNING = ''
+        cls.FAIL = ''
+        cls.ENDC = ''
 
 
 class Storage:
@@ -291,6 +293,8 @@ def fetchname(name=sys.argv[0]):
 
 if __name__ == '__main__':
     try:
+        if platform.system().lower() == 'windows':
+            C.disable()
         name = fetchname()
         if name:
             cmd = argparse_and_cmd([name] + sys.argv[1:])


### PR DESCRIPTION
Win32 console doesn't support ANSI. This patch auto-disables console output colorization when Windows detected.
