### PR TITLE
adds opt colorama support (Windows-only)

### DIFF
--- a/c
+++ b/c
@@ -27,6 +27,14 @@ class C:
     ENDC = '\033[0m'
 
     @classmethod
+    def via_colorama(cls):
+        cls.HEADER = '\033[35;40;1m'
+        cls.OKBLUE = '\033[36;40;1m'
+        cls.OKGREEN = '\033[32;40;1m'
+        cls.WARNING = '\033[33;40;1m'
+        cls.FAIL = '\033[31;40;1m'
+
+    @classmethod
     def disable(cls):
         cls.HEADER = ''
         cls.OKBLUE = ''
@@ -306,7 +314,13 @@ def fetchname(name=sys.argv[0]):
 if __name__ == '__main__':
     try:
         if platform.system().lower() == 'windows':
-            C.disable()
+            try:
+                from colorama import init
+                init()
+                C.via_colorama()
+            except:
+                C.disable()
+                print('You probably would love to run command \'easy_install colorama\' at first ;)')
         name = fetchname()
         if name:
             cmd = argparse_and_cmd([name] + sys.argv[1:])


### PR DESCRIPTION
if user has colorama installed, s/he get colours (imagine!);
if not, they're gotta get 'an offer they can't refuse'

![pic 2013-06-15 15 44 43](https://f.cloud.github.com/assets/1975298/657900/c31bf6a2-d59b-11e2-9f73-0845193cff8f.png)

Could you please try it and let me know if something wrong?

P.S. You may notice issue with new name on screenshot, I ran it with Python 2.7.\* so maybe this is a reason, anyway I'm going to investigate it later.
P.P.S. I've put black background to keep it readable no matter what colour background is used in console.
